### PR TITLE
Update simplify_map.R

### DIFF
--- a/simplify_map.R
+++ b/simplify_map.R
@@ -65,7 +65,7 @@ for (i in 1: num) {
 					ends = names(which(degree(cutg) == 1))
 					path = get.shortest.paths(cutg, ends[1], ends[2])[[1]]
 					# this is an index into the points
-					pathX = as.numeric(V(x.asg)[path]$name)
+					pathX = as.numeric(V(x.asg)[path[[1]]]$name)
 					# join the ends
 					pathX = c(pathX, pathX[1])
 					p = Polygon(x.as$x[pathX, ])


### PR DESCRIPTION
V() was throwing an Vertex Index Error. I believe this may be due to using a later version of igraph (v0.7). This fix removes the error and does not cause backwards compatibility problems.
